### PR TITLE
Made the ServiceProvider compatible with Laravel 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,15 @@ A minimal service provider to set up and use InfluxDB SDK in Laravel 5
 ### Installation
 - Add a line to *require* section of `composer.json` and execute `$ composer install`
 ```js
+"repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/pvgennip/laravel-influx-provider"
+        }
+    ],
 "require": {
 //  ...
-    "pvgennip/laravel-influx-provider": "^1.3"
+    "pvgennip/laravel-influx-provider": "dev-laravel-5.4"
 }
 ```
 - Add these lines to `config/app.php`

--- a/README.md
+++ b/README.md
@@ -4,9 +4,15 @@ A minimal service provider to set up and use InfluxDB SDK in Laravel 5
 ### Installation
 - Add a line to *require* section of `composer.json` and execute `$ composer install`
 ```js
+"repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/pvgennip/laravel-influx-provider"
+        }
+    ],
 "require": {
 //  ...
-    "pvgennip/laravel-influx-provider": "^1.3"
+    "pvgennip/laravel-influx-provider": "dev-laravel-5.4"
 }
 ```
 - Add a line to `config/app.php`

--- a/README.md
+++ b/README.md
@@ -2,8 +2,14 @@
 A minimal service provider to set up and use InfluxDB SDK in Laravel 5
 
 ### Installation
-- Add a line to *require* section of `composer.json` and execute `$ composer install`
+- Add these lines betofe AND to *require* section of `composer.json` and execute `$ composer install`
 ```js
+"repositories": [
+    {
+        "type": "vcs",
+        "url": "https://github.com/pvgennip/laravel-influx-provider"
+    }
+],
 "require": {
 //  ...
     "pvgennip/laravel-influx-provider": "dev-master"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A minimal service provider to set up and use InfluxDB SDK in Laravel 5
 ```js
 "require": {
 //  ...
-    "pdffiller/laravel-influx-provider": "^1.2"
+    "pvgennip/laravel-influx-provider": "^1.3"
 }
 ```
 - Add a line to `config/app.php`

--- a/README.md
+++ b/README.md
@@ -9,13 +9,22 @@ A minimal service provider to set up and use InfluxDB SDK in Laravel 5
     "pvgennip/laravel-influx-provider": "^1.3"
 }
 ```
-- Add a line to `config/app.php`
+- Add these lines to `config/app.php`
 ```php
 'providers' => [
 //  ...
     Pdffiller\LaravelInfluxProvider\InfluxDBServiceProvider::class,
 ]
+
+
+'aliases' => [
+// ...
+    'Influx' => Pdffiller\LaravelInfluxProvider\InfluxDBFacade::class,
+]
+
 ```
+
+
 - Define env variables to connect to InfluxDB
 ```
 LARAVEL_INFLUX_PROVIDER_PROTOCOL=http

--- a/README.md
+++ b/README.md
@@ -4,15 +4,9 @@ A minimal service provider to set up and use InfluxDB SDK in Laravel 5
 ### Installation
 - Add a line to *require* section of `composer.json` and execute `$ composer install`
 ```js
-"repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/pvgennip/laravel-influx-provider"
-        }
-    ],
 "require": {
 //  ...
-    "pvgennip/laravel-influx-provider": "dev-laravel-5.4"
+    "pvgennip/laravel-influx-provider": "dev-master"
 }
 ```
 - Add these lines to `config/app.php`
@@ -42,6 +36,11 @@ LARAVEL_INFLUX_PROVIDER_DATABASE=database_name
 ```
 
 ### How to use
+```php
+$client = new \Influx;
+$data   = $client::query('SELECT * from "data" ORDER BY time DESC LIMIT 1');
+```
+
 ```php
 $point = [
     new \InfluxDB\Point(

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "pdffiller/laravel-influx-provider",
+  "name": "pvgennip/laravel-influx-provider",
   "description": "Service provider to set up and use InfluxDB SDK in Laravel 5",
   "keywords": ["influx-db", "laravel"],
   "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
   ],
   "require": {
     "php": ">=5.6",
-    "illuminate/log": "5.2.*|5.3.*",
-    "illuminate/support": "5.2.*|5.3.*",
+    "illuminate/log": "5.2.*|5.3.*|5.4.*",
+    "illuminate/support": "5.2.*|5.3.*|5.4.*",
     "influxdb/influxdb-php": "^1.4",
     "monolog/monolog": "^1.19"
   },

--- a/src/InfluxDBServiceProvider.php
+++ b/src/InfluxDBServiceProvider.php
@@ -14,8 +14,10 @@ class InfluxDBServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishes([
-            __DIR__ . '/config/InfluxDB.php' => config_path('influxdb.php')
+            $this->configPath() => config_path('influxdb.php')
         ]);
+        
+        $this->mergeConfigFrom($this->configPath(), 'influxdb');
 
         if (config('influxdb.use_monolog_handler') === 'true') {
             $handler = new InfluxDBMonologHandler($this->getLoggingLevel());
@@ -32,6 +34,7 @@ class InfluxDBServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app->singleton('InfluxDB\Client', function($app) {
+
             $protocol = 'influxdb';
             if (in_array(config('influxdb.protocol'), ['https', 'udp'])) {
                 $protocol = config('influxdb.protocol') . '+' . $protocol;
@@ -66,5 +69,10 @@ class InfluxDBServiceProvider extends ServiceProvider
             'ALERT',
             'EMERGENCY'
         ]) ? config('influxdb.logging_level') : Logger::NOTICE;
+    }
+
+    protected function configPath()
+    {
+        return __DIR__ . '/config/InfluxDB.php';
     }
 }


### PR DESCRIPTION
Thank you for the nice ServiceProvider!
I wanted to use it with the newest version of Laravel, but composer told me that your version was not compatible, so I made it compatible.

I had to change the composer.json to test is, but maybe you can review the changes and make your version also compatible with Laravel 5.4.