### PR TITLE
Add connect_timeout for guzzle

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A minimal service provider to set up and use InfluxDB SDK in Laravel 5
 ```js
 "require": {
 //  ...
-    "pdffiller/laravel-influx-provider": "^1.2"
+    "pdffiller/laravel-influx-provider": "^1.6"
 }
 ```
 - Add these lines to `config/app.php`
@@ -33,6 +33,9 @@ LARAVEL_INFLUX_PROVIDER_PASSWORD=some_password
 LARAVEL_INFLUX_PROVIDER_HOST=host
 LARAVEL_INFLUX_PROVIDER_PORT=8086
 LARAVEL_INFLUX_PROVIDER_DATABASE=database_name
+LARAVEL_INFLUX_PROVIDER_VERIFY_SSL=false
+LARAVEL_INFLUX_PROVIDER_TIMEOUT=0
+LARAVEL_INFLUX_PROVIDER_CONNECT_TIMEOUT=0
 ```
 
 ### How to use

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "php": ">=5.6",
     "illuminate/log": "5.2.*|5.3.*|5.4.*",
     "illuminate/support": "5.2.*|5.3.*|5.4.*",
-    "influxdb/influxdb-php": "^1.4",
+    "influxdb/influxdb-php": "1.14.*",
     "monolog/monolog": "^1.19"
   },
   "require-dev": {

--- a/src/InfluxDBServiceProvider.php
+++ b/src/InfluxDBServiceProvider.php
@@ -48,7 +48,10 @@ class InfluxDBServiceProvider extends ServiceProvider
                         config('influxdb.host'),
                         config('influxdb.port'),
                         '' //config('influxdb.database')
-                    ), config('influxdb.timeout')
+                    ),
+                    config('influxdb.timeout'),
+                    (config('influxdb.verify_ssl') === 'true'),
+                    config('influxdb.connect_timeout')
                 );
             } catch (ClientException $e) {
                 // die silently

--- a/src/config/InfluxDB.php
+++ b/src/config/InfluxDB.php
@@ -39,7 +39,17 @@ return [
     'log_message_lines_limit' => env('LARAVEL_INFLUX_PROVIDER_LOG_MESSAGE_LINES_LIMIT', 5),
 
     /**
+     * Verify SSL
+     */
+    'verify_ssl' => env('LARAVEL_INFLUX_PROVIDER_VERIFY_SSL', 'false'),
+
+    /**
      * Timeout
      */
     'timeout' => env('LARAVEL_INFLUX_PROVIDER_TIMEOUT', 0),
+
+    /**
+    * Connect Timeout
+    */
+    'connect_timeout' => env('LARAVEL_INFLUX_PROVIDER_CONNECT_TIMEOUT', 0),
 ];


### PR DESCRIPTION
Without this functionality, Guzzle causes server timeout when remote cannot be found. This is essential!